### PR TITLE
Remove unused browserify dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 
 var sio = require('socket.io');
-var browserify = require('browserify-middleware');
 var forwarded = require('forwarded-for');
 var debug = require('debug');
 

--- a/package.json
+++ b/package.json
@@ -10,10 +10,6 @@
     "socket.io": "1.3.7",
     "socket.io-redis": "1.0.0"
   },
-  "devDependencies": {
-    "browserify": "3.31.2",
-    "browserify-middleware": "2.3.0"
-  },
   "scripts": {
     "start": "node index.js"
   }


### PR DESCRIPTION
I didn't find any use of that dependency, and it causes `npm install` to crash with `npm ERR! No compatible version found: esprima-six@~0.0.3`

Fix #23
